### PR TITLE
Process OCR files by file id

### DIFF
--- a/lib/Exception/OcrProcessorNotFoundException.php
+++ b/lib/Exception/OcrProcessorNotFoundException.php
@@ -26,4 +26,7 @@ namespace OCA\WorkflowOcr\Exception;
 use Exception;
 
 class OcrProcessorNotFoundException extends Exception {
+	public function __construct(string $mimeType) {
+		$this->message = 'OCR processor for mime type ' . $mimeType . ' not found';
+	}
 }

--- a/lib/OcrProcessors/OcrMyPdfBasedProcessor.php
+++ b/lib/OcrProcessors/OcrMyPdfBasedProcessor.php
@@ -72,7 +72,7 @@ abstract class OcrMyPdfBasedProcessor implements IOcrProcessor {
 		$exitCode = $this->command->getExitCode();
 
 		if (!$success) {
-			throw new OcrNotPossibleException('OCRmyPDF exited abnormally with exit-code ' . $exitCode . '. Message: ' . $errorOutput . ' ' . $stdErr);
+			throw new OcrNotPossibleException('OCRmyPDF exited abnormally with exit-code ' . $exitCode . ' for file ' . $file->getPath() . '. Message: ' . $errorOutput . ' ' . $stdErr);
 		}
 
 		if ($stdErr !== '' || $errorOutput !== '') {
@@ -86,7 +86,7 @@ abstract class OcrMyPdfBasedProcessor implements IOcrProcessor {
 		$ocrFileContent = $this->command->getOutput();
 
 		if (!$ocrFileContent) {
-			throw new OcrNotPossibleException('OCRmyPDF did not produce any output');
+			throw new OcrNotPossibleException('OCRmyPDF did not produce any output for file ' . $file->getPath());
 		}
 
 		$recognizedText = $this->sidecarFileAccessor->getSidecarFileContent();

--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -107,7 +107,7 @@ class Operation implements ISpecificOperation {
 		if (!($match = $this->getMatch($ruleMatcher)) ||
 			!$this->tryGetFile($eventName, $event, $node) ||
 			$this->eventTriggeredByOcrProcess($node) ||
-			!$this->tryGetJobArgs($node, $match, $argsArray)) {
+			!$this->tryGetJobArgs($node, $match['operation'], $argsArray)) {
 			return;
 		}
 	
@@ -192,14 +192,14 @@ class Operation implements ISpecificOperation {
 
 	/**
 	 * @param Node $node
-	 * @param array $match
+	 * @param string $operation
 	 * @param array $argsArray
 	 */
-	private function tryGetJobArgs(Node $node, $match, & $argsArray) : bool {
+	private function tryGetJobArgs(Node $node, $operation, & $argsArray) : bool {
 		// Check path has valid structure
 		$filePath = $node->getPath();
 		// '', admin, 'files', 'path/to/file.pdf'
-		[,, $folder,] = explode('/', $filePath, 4);
+		[, $user, $folder,] = explode('/', $filePath, 4);
 		if ($folder !== 'files') {
 			$this->logger->debug('Not processing event because path \'{path}\' seems to be invalid.',
 				['path' => $filePath]);
@@ -207,8 +207,9 @@ class Operation implements ISpecificOperation {
 		}
 
 		$argsArray = [
-			'filePath' => $filePath,
-			'settings' => $match['operation']
+			'uid' => $user,
+			'fileId' => $node->getId(),
+			'settings' => $operation
 		];
 
 		return true;

--- a/tests/Integration/Notification/NotificationTest.php
+++ b/tests/Integration/Notification/NotificationTest.php
@@ -151,7 +151,7 @@ class NotificationTest extends TestCase {
 
 		$this->processFileJob->setId(111);
 		$this->processFileJob->setArgument([
-			'filePath' => '/admin/files/somefile.pdf',
+			'fileId' => 42,
 			'uid' => 'someuser',
 			'settings' => '{}'
 		]);
@@ -159,9 +159,9 @@ class NotificationTest extends TestCase {
 
 	public function testBackgroundJobCreatesErrorNotificationIfOcrFailed() {
 		$fileMock = $this->createValidFileMock();
-		$this->rootFolder->method('get')
-			->with('/admin/files/somefile.pdf')
-			->willReturn($fileMock);
+		$this->rootFolder->method('getById')
+			->with(42)
+			->willReturn([$fileMock]);
 
 		$this->ocrService->expects($this->once())
 			->method('ocrFile')
@@ -177,7 +177,7 @@ class NotificationTest extends TestCase {
 		$notification = $notifications[0];
 		$this->assertEquals('workflow_ocr', $notification->getApp());
 		$this->assertEquals('ocr_error', $notification->getSubject());
-		$this->assertEquals('OCR for file /admin/files/somefile.pdf not possible. Message: Some error', $notification->getSubjectParameters()['message']);
+		$this->assertEquals('An error occured while executing the OCR process (Some error). Please have a look at your servers logfile for more details.', $notification->getSubjectParameters()['message']);
 	}
 
 	/**

--- a/tests/Unit/OcrProcessors/PdfOcrProcessorTest.php
+++ b/tests/Unit/OcrProcessors/PdfOcrProcessorTest.php
@@ -165,6 +165,9 @@ class PdfOcrProcessorTest extends TestCase {
 			->method('getStdErr')
 			->willReturn('stdErr');
 		$this->ocrMyPdfOutput = "";
+		$this->fileBefore->expects($this->once())
+			->method('getPath')
+			->willReturn('/admin/files/somefile.pdf');
 
 		$thrown = false;
 		$processor = new PdfOcrProcessor($this->command, $this->logger, $this->sidecarFileAccessor);
@@ -174,7 +177,7 @@ class PdfOcrProcessorTest extends TestCase {
 		} catch (\Throwable $t) {
 			$thrown = true;
 			$this->assertInstanceOf(OcrNotPossibleException::class, $t);
-			$this->assertEquals('OCRmyPDF did not produce any output', $t->getMessage());
+			$this->assertEquals('OCRmyPDF did not produce any output for file /admin/files/somefile.pdf', $t->getMessage());
 		}
 
 		$this->assertTrue($thrown);

--- a/tests/Unit/OperationTest.php
+++ b/tests/Unit/OperationTest.php
@@ -210,10 +210,11 @@ class OperationTest extends TestCase {
 
 	public function testAddWithCorrectFilePathAndUser() {
 		$filePath = "/admin/files/path/to/file.pdf";
+		$fileId = 42;
 		$uid = 'admin';
 		$this->jobList->expects($this->once())
 			->method('add')
-			->with(ProcessFileJob::class, ['filePath' => $filePath, 'settings' => self::SETTINGS]);
+			->with(ProcessFileJob::class, ['fileId' => $fileId, 'uid' => $uid, 'settings' => self::SETTINGS]);
 
 		$operation = new Operation($this->jobList, $this->l, $this->logger, $this->urlGenerator, $this->processingFileAccessor, $this->rootFolder);
 
@@ -231,7 +232,7 @@ class OperationTest extends TestCase {
 		$fileMock->method('getOwner')
 			->willReturn($userMock);
 		$fileMock->method('getId')
-			->willReturn(42);
+			->willReturn($fileId);
 		$event = new GenericEvent($fileMock);
 		$eventName = '\OCP\Files::postCreate';
 
@@ -403,7 +404,7 @@ class OperationTest extends TestCase {
 
 		$this->jobList->expects($this->once())
 			->method('add')
-			->with(ProcessFileJob::class, ['filePath' => $filePath, 'settings' => self::SETTINGS]);
+			->with(ProcessFileJob::class, ['fileId' => $fileId, 'uid' => $uid, 'settings' => self::SETTINGS]);
 
 		/** @var MockObject|IUser */
 		$userMock = $this->createMock(IUser::class);


### PR DESCRIPTION
Closing #112

**Testplan**

* Ensure that OCR processing for PDF and JPG files still works as before
* Create manual testcase where we upload a matching document but before triggering `cron.php` we rename the file. OCR process should still work afterwards.

**Artifact**

Install artifact for NC28: https://github.com/R0Wi-DEV/workflow_ocr/suites/15532932389/artifacts/886555625