### PR TITLE
[Backport stable28] Build(deps-dev): Bump express from 4.18.2 to 4.19.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8208,9 +8208,9 @@
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
 		},
 		"node_modules/cookie": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
@@ -10873,17 +10873,17 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "4.18.2",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-			"integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+			"version": "4.19.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+			"integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
 			"dev": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.20.1",
+				"body-parser": "1.20.2",
 				"content-disposition": "0.5.4",
 				"content-type": "~1.0.4",
-				"cookie": "0.5.0",
+				"cookie": "0.6.0",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
@@ -10920,30 +10920,6 @@
 			"integrity": "sha512-swxwm3aP8vrOOvlzOdZvHlSZtJGwHKaY94J6AkrAgCTmcbko3IRwbkhLv2wKV1WeZhjxX58aLMpP3atDBnKuZg==",
 			"dev": true
 		},
-		"node_modules/express/node_modules/body-parser": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-			"integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-			"dev": true,
-			"dependencies": {
-				"bytes": "3.1.2",
-				"content-type": "~1.0.4",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"on-finished": "2.4.1",
-				"qs": "6.11.0",
-				"raw-body": "2.5.1",
-				"type-is": "~1.6.18",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8",
-				"npm": "1.2.8000 || >= 1.4.16"
-			}
-		},
 		"node_modules/express/node_modules/debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -10958,21 +10934,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true
-		},
-		"node_modules/express/node_modules/raw-body": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-			"integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-			"dev": true,
-			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/ext-list": {
 			"version": "2.2.2",


### PR DESCRIPTION
Backport 999be0ab74f9e15b23d11d2f320301e3540d3c55 from #245