### PR TITLE
Check if user can update node

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -959,12 +959,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "15a749fe867b97ae5e699a3ce9e1d50a792c1777"
+                "reference": "3d9b3b4d13b3a8ad441c1fd862dd7365e72840dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/15a749fe867b97ae5e699a3ce9e1d50a792c1777",
-                "reference": "15a749fe867b97ae5e699a3ce9e1d50a792c1777",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/3d9b3b4d13b3a8ad441c1fd862dd7365e72840dd",
+                "reference": "3d9b3b4d13b3a8ad441c1fd862dd7365e72840dd",
                 "shasum": ""
             },
             "require": {
@@ -1000,7 +1000,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-12-21T00:43:01+00:00"
+            "time": "2025-01-15T00:42:43+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -1178,16 +1178,16 @@
         },
         {
             "name": "php-cs-fixer/shim",
-            "version": "v3.65.0",
+            "version": "v3.68.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/shim.git",
-                "reference": "4983ec79b9dee926695ac324ea6e8d291935525d"
+                "reference": "23acc692a99304559d4c94e9f299158ecd0ed7d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/4983ec79b9dee926695ac324ea6e8d291935525d",
-                "reference": "4983ec79b9dee926695ac324ea6e8d291935525d",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/23acc692a99304559d4c94e9f299158ecd0ed7d1",
+                "reference": "23acc692a99304559d4c94e9f299158ecd0ed7d1",
                 "shasum": ""
             },
             "require": {
@@ -1224,9 +1224,9 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/shim/issues",
-                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.65.0"
+                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.68.0"
             },
-            "time": "2024-11-25T00:39:41+00:00"
+            "time": "2025-01-13T17:01:38+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3347,12 +3347,12 @@
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
                 "branch-alias": {
                     "dev-main": "3.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -3803,12 +3803,12 @@
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
                 "branch-alias": {
                     "dev-main": "3.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {

--- a/lib/Helper/IProcessingFileAccessor.php
+++ b/lib/Helper/IProcessingFileAccessor.php
@@ -25,15 +25,15 @@ namespace OCA\WorkflowOcr\Helper;
 
 interface IProcessingFileAccessor {
 	/**
-	 * Returns the id of the file which is currently
+	 * Returns the path of the file which is currently
 	 * processed via OCR
-	 * @return ?int
+	 * @return ?string
 	 */
-	public function getCurrentlyProcessedFileId() : ?int;
+	public function getCurrentlyProcessedFilePath() : ?string;
 
 	/**
-	 * Sets the id of the file which is currently
+	 * Sets the path of the file which is currently
 	 * processed via OCR
 	 */
-	public function setCurrentlyProcessedFileId(?int $fileId) : void;
+	public function setCurrentlyProcessedFilePath(?string $filePath) : void;
 }

--- a/lib/Helper/ProcessingFileAccessor.php
+++ b/lib/Helper/ProcessingFileAccessor.php
@@ -24,15 +24,15 @@ declare(strict_types=1);
 namespace OCA\WorkflowOcr\Helper;
 
 /**
- * This class is a singleton which holds the id
+ * This class is a singleton which holds the path
  * of the currently OCR processed file. This ensures
  * that a files is not added to the processing queue
  * if the 'postWrite' hook was triggered by a new
  * version created by the OCR process.
  */
 class ProcessingFileAccessor implements IProcessingFileAccessor {
-	/** @var ?int */
-	private $currentlyProcessedFileId;
+	/** @var ?string */
+	private $currentlyProcessedFilePath;
 
 	/** @var ProcessingFileAccessor */
 	private static $instance;
@@ -50,14 +50,14 @@ class ProcessingFileAccessor implements IProcessingFileAccessor {
 	/**
 	 * @inheritdoc
 	 */
-	public function getCurrentlyProcessedFileId() : ?int {
-		return $this->currentlyProcessedFileId;
+	public function getCurrentlyProcessedFilePath() : ?string {
+		return $this->currentlyProcessedFilePath;
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function setCurrentlyProcessedFileId(?int $fileId) : void {
-		$this->currentlyProcessedFileId = $fileId;
+	public function setCurrentlyProcessedFilePath(?string $filePath) : void {
+		$this->currentlyProcessedFilePath = $filePath;
 	}
 }

--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -226,7 +226,7 @@ class Operation implements ISpecificOperation {
 
 	private function eventTriggeredByOcrProcess(Node $node) : bool {
 		// Check if the event was triggered by OCR rewrite of the file
-		if ($node->getId() === $this->processingFileAccessor->getCurrentlyProcessedFileId()) {
+		if ($node->getPath() === $this->processingFileAccessor->getCurrentlyProcessedFilePath()) {
 			$this->logger->debug('Not processing event because file with path \'{path}\' was written by OCR process.',
 				['path' => $node->getPath()]);
 			return true;

--- a/tests/Unit/Helper/ProcessingFIleAccessorTest.php
+++ b/tests/Unit/Helper/ProcessingFIleAccessorTest.php
@@ -36,8 +36,8 @@ class ProcessingFileAccessorTest extends TestCase {
 	
 	public function testGetSet() {
 		$o = ProcessingFileAccessor::getInstance();
-		$o ->setCurrentlyProcessedFileId(42);
-		$this->assertEquals(42, $o->getCurrentlyProcessedFileId());
-		$o->setCurrentlyProcessedFileId(null);
+		$o ->setCurrentlyProcessedFilePath('/someuser/files/somefile.pdf');
+		$this->assertEquals('/someuser/files/somefile.pdf', $o->getCurrentlyProcessedFilePath());
+		$o->setCurrentlyProcessedFilePath(null);
 	}
 }


### PR DESCRIPTION
...and change to an alternative user if not (fixes ocr for filedrop and groupfolder acl).

@R0Wi This is just a rough proof of concept to fix https://github.com/R0Wi-DEV/workflow_ocr/issues/273
In comparison to the discussion at https://github.com/R0Wi-DEV/workflow_ocr/issues/110 (https://github.com/R0Wi-DEV/workflow_ocr/pull/116) this approach does first check whether the current user has the permissions to update the node. If not, an alternative user is chosen (but not owner, because this may fail for groupfolders).

This draft does not include a setting, test or further documentation. I'm also wondering whether the manual implementation for `createNewFileVersion` is really required.
https://github.com/R0Wi-DEV/workflow_ocr/blob/56be914f12b80fcc7e26d9f85d4f0e0633bcae28/lib/Service/OcrService.php#L163

Wouldn't `$node->putContent`be enough?
https://github.com/nextcloud/server/blob/2651d4964ec26696b5f8b1f5db48588a5d09ab01/lib/private/Files/Node/File.php#L49