### PR TITLE
Fix: discard notifications for deleted files instead of logging warnings repeatedly

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -103,18 +103,20 @@ class Notifier implements INotifier {
 		}
 
 		// Only add file info if we have some ...
-		$richParams = false;
+		$richParams = null;
 		if ($notification->getObjectType() === 'file'
 			&& ($fileId = $notification->getObjectId())
 			&& ($uid = $notification->getUser())) {
+			// Note:: This might throw an AlreadyProcessedException if the file doesn't exist anymore.
+			// It has to be thrown before any call to $notification->set... otherwise the notification
+			// won't be removed from the database.
 			$richParams = $this->tryGetRichParamForFile($uid, intval($fileId));
-			if ($richParams !== false) {
-				$notification->setRichSubject($richSubject, $richParams);
-			}
 		}
 
-		// Fallback to generic error message without file link
-		if ($richParams === false) {
+		if ($richParams !== null) {
+			$notification->setRichSubject($richSubject, $richParams);
+		} else {
+			// Fallback to generic error message without file link
 			$notification->setParsedSubject($parsedSubject);
 		}
 
@@ -129,21 +131,38 @@ class Notifier implements INotifier {
 		return $notification;
 	}
 
-	private function tryGetRichParamForFile(string $uid, int $fileId) : array|bool {
+	/**
+	 * Tries to build the rich notification parameters pointing to the file the
+	 * notification was created for.
+	 *
+	 * @return array|null The rich parameters or `null` if they could not be determined
+	 *                    because of an unexpected error.
+	 * @throws AlreadyProcessedException If the file cannot be found for the given user
+	 *                                   anymore. In that case the notification is obsolete
+	 *                                   and gets removed from the database instead of being
+	 *                                   re-rendered on every notification poll (see #382).
+	 */
+	private function tryGetRichParamForFile(string $uid, int $fileId) : ?array {
 		try {
 			$userFolder = $this->rootFolder->getUserFolder($uid);
-			/** @var File[] */
-			$files = $userFolder->getById($fileId);
-			/** @var File $file */
-			$file = array_shift($files);
-			if ($file === null) {
-				$this->logger->warning('Could not find file with id {fileId} for user {uid}', ['fileId' => $fileId, 'uid' => $uid]);
-				return false;
-			}
-			$relativePath = $userFolder->getRelativePath($file->getPath());
+			/** @var File|null $file */
+			$file = $userFolder->getFirstNodeById($fileId);
+			$relativePath = $file !== null ? $userFolder->getRelativePath($file->getPath()) : null;
 		} catch (\Throwable $th) {
 			$this->logger->error($th->getMessage(), ['exception' => $th]);
-			return false;
+			return null;
+		}
+
+		if ($file === null) {
+			// Nothing unusual: the user might have deleted the file (or moved it to the
+			// trashbin) after the OCR process has finished. Since we cannot render a link
+			// to the file anymore, the notification is dropped. This also prevents the
+			// message from being logged over and over again, because the notifications app
+			// re-renders every stored notification on each poll.
+			$this->logger->debug('Could not find file with id {fileId} for user {uid}, discarding obsolete notification', ['fileId' => $fileId, 'uid' => $uid]);
+			// Note:: AlreadyProcessedException has to be thrown before any call to $notification->set...
+			// otherwise notification won't be removed from the database
+			throw new AlreadyProcessedException();
 		}
 
 		return [

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -27,8 +27,8 @@ declare(strict_types=1);
 namespace OCA\WorkflowOcr\Notification;
 
 use OCA\WorkflowOcr\AppInfo\Application;
-use OCP\Files\File;
 use OCP\Files\IRootFolder;
+use OCP\Files\Node;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
 use OCP\Notification\AlreadyProcessedException;
@@ -145,7 +145,7 @@ class Notifier implements INotifier {
 	private function tryGetRichParamForFile(string $uid, int $fileId) : ?array {
 		try {
 			$userFolder = $this->rootFolder->getUserFolder($uid);
-			/** @var File|null $file */
+			/** @var Node|null $file */
 			$file = $userFolder->getFirstNodeById($fileId);
 			$relativePath = $file !== null ? $userFolder->getRelativePath($file->getPath()) : null;
 		} catch (\Throwable $th) {
@@ -160,8 +160,9 @@ class Notifier implements INotifier {
 			// message from being logged over and over again, because the notifications app
 			// re-renders every stored notification on each poll.
 			$this->logger->debug('Could not find file with id {fileId} for user {uid}, discarding obsolete notification', ['fileId' => $fileId, 'uid' => $uid]);
-			// Note:: AlreadyProcessedException has to be thrown before any call to $notification->set...
-			// otherwise notification won't be removed from the database
+			// Note:: The caller (prepare()) must not call $notification->set... before invoking this
+			// method, otherwise the notification won't be removed from the database once this
+			// exception is thrown.
 			throw new AlreadyProcessedException();
 		}
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -28,7 +28,6 @@ namespace OCA\WorkflowOcr\Notification;
 
 use OCA\WorkflowOcr\AppInfo\Application;
 use OCP\Files\IRootFolder;
-use OCP\Files\Node;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
 use OCP\Notification\AlreadyProcessedException;
@@ -145,7 +144,6 @@ class Notifier implements INotifier {
 	private function tryGetRichParamForFile(string $uid, int $fileId) : ?array {
 		try {
 			$userFolder = $this->rootFolder->getUserFolder($uid);
-			/** @var Node|null $file */
 			$file = $userFolder->getFirstNodeById($fileId);
 			$relativePath = $file !== null ? $userFolder->getRelativePath($file->getPath()) : null;
 		} catch (\Throwable $th) {

--- a/tests/Unit/Notification/NotifierTest.php
+++ b/tests/Unit/Notification/NotifierTest.php
@@ -156,9 +156,9 @@ class NotifierTest extends TestCase {
 		/** @var Folder|MockObject */
 		$userFolder = $this->createMock(Folder::class);
 		$userFolder->expects($this->once())
-			->method('getById')
-			->with('123')
-			->willReturn(['file' => $file]);
+			->method('getFirstNodeById')
+			->with(123)
+			->willReturn($file);
 		$userFolder->expects($this->once())
 			->method('getRelativePath')
 			->with('admin/files/file.txt')
@@ -256,8 +256,8 @@ class NotifierTest extends TestCase {
 		$userFolder = $this->createMock(Folder::class);
 		$ex = new \OCP\Files\NotFoundException('nope ... sorry');
 		$userFolder->expects($this->once())
-			->method('getById')
-			->with('123')
+			->method('getFirstNodeById')
+			->with(123)
 			->willThrowException($ex); // This is what we want to test ...
 		$userFolder->expects($this->never())
 			->method('getRelativePath');
@@ -283,7 +283,10 @@ class NotifierTest extends TestCase {
 		$this->assertEquals('<translated> Workflow OCR error', $notification->getParsedSubject());
 	}
 
-	public function testSendsFallbackNotificationWithoutFileInfoIfReturnedFileArrayWasEmpty() {
+	/**
+	 * @see https://github.com/R0Wi-DEV/workflow_ocr/issues/382
+	 */
+	public function testThrowsAlreadyProcessedExceptionIfFileCannotBeFoundAnymore() {
 		/** @var IValidator|MockObject */
 		$validator = $this->createMock(IValidator::class);
 		/** @var IRichTextFormatter|MockObject */
@@ -305,31 +308,30 @@ class NotifierTest extends TestCase {
 		/** @var Folder|MockObject */
 		$userFolder = $this->createMock(Folder::class);
 		$userFolder->expects($this->once())
-			->method('getById')
-			->with('123')
-			->willReturn([]); // This is what we want to test ...
+			->method('getFirstNodeById')
+			->with(123)
+			->willReturn(null); // This is what we want to test ...
 		$userFolder->expects($this->never())
 			->method('getRelativePath');
 		$this->rootFolder->expects($this->once())
 			->method('getUserFolder')
 			->with('user')
 			->willReturn($userFolder);
-		$this->urlGenerator->expects($this->once())
-			->method('imagePath')
-			->with('workflow_ocr', 'app-dark.svg')
-			->willReturn('apps/workflow_ocr/app-dark.svg');
-		$this->urlGenerator->expects($this->once())
-			->method('getAbsoluteURL')
-			->with('apps/workflow_ocr/app-dark.svg')
-			->willReturn('http://localhost/index.php/apps/workflow_ocr/app-dark.svg');
+		// The notification is dropped, so it's never rendered
+		$this->urlGenerator->expects($this->never())
+			->method('imagePath');
+		$this->urlGenerator->expects($this->never())
+			->method('linkToRouteAbsolute');
+		// A missing file is expected (e.g. user deleted it), so no warning should be logged
+		$this->logger->expects($this->never())
+			->method('warning');
 		$this->logger->expects($this->once())
-			->method('warning')
-			->with('Could not find file with id {fileId} for user {uid}', ['fileId' => '123', 'uid' => 'user']);
+			->method('debug')
+			->with('Could not find file with id {fileId} for user {uid}, discarding obsolete notification', ['fileId' => 123, 'uid' => 'user']);
 
-		$notification = $this->notifier->prepare($notification, 'en');
+		$this->expectException(AlreadyProcessedException::class);
 
-		$this->assertEmpty($notification->getRichSubject());
-		$this->assertEquals('<translated> Workflow OCR error', $notification->getParsedSubject());
+		$this->notifier->prepare($notification, 'en');
 	}
 
 	public function testFallbackToParsedSubjectIfMessageIsEmpty() {


### PR DESCRIPTION
## Summary

Fixes #382. When a user deletes a file after workflow_ocr has created a success or error notification for it, the notification's row in `oc_notifications` persists. Because the notifications app re-renders every stored notification on each poll of `/ocs/v2.php/apps/notifications/api/v2/notifications`, the notifier would log a warning every time—multiple times per minute—cluttering the Nextcloud logs indefinitely.

## Changes

- **`tryGetRichParamForFile()`**: Now throws `AlreadyProcessedException` when the file cannot be found for the given user, instead of logging a warning and returning false. This signals Nextcloud to delete the notification row from the database, stopping the recurring logs.
- **Log level**: Lowered from `warning` to `debug` for the missing-file case, since users deleting files (or moving them to trashbin) after OCR completes is a normal situation, not an error worth warning about.
- **API switch**: Replaced `getById()` + `array_shift()` with `getFirstNodeById()` for cleaner code.
- **Test updates**: Replaced the "fallback when file array was empty" test with `testThrowsAlreadyProcessedExceptionIfFileCannotBeFoundAnymore`, which verifies the notification is discarded and only `debug` is logged.

Unexpected errors while resolving the file still produce an `error` log and fall back to the generic subject without a file link.

## Testing

Unit tests pass (9/9 with 70 assertions) against a local harness. `composer cs:check` is clean. The test suite will run in CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M3aC9zhcgYNxtr2n4pZUaE)_