### PR TITLE
Add DevContainer configuration for local development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -81,10 +81,24 @@ RUN mkdir -p /var/www/nextcloud/apps && chown -R ${APACHE_RUN_USER}:${APACHE_RUN
 
 RUN mkdir -p /home/${APACHE_RUN_USER}/.claude && chown -R ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} /home/${APACHE_RUN_USER}/.claude
 
+# Playwright browser directory, created as root because $APACHE_RUN_USER may
+# not write to /. Owned by that user so `playwright install` below can fill it.
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN mkdir -p ${PLAYWRIGHT_BROWSERS_PATH} && \
+    chown ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} ${PLAYWRIGHT_BROWSERS_PATH}
+
 USER devcontainer
 
 # NVM / NodeJS (matches this app's package.json engines)
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 RUN bash --login -i -c 'source /home/devcontainer/.bashrc && nvm install 24'
+
+# Chrome + libs for the Playwright MCP server (`npx @playwright/mcp@latest`,
+# see .mcp.json) so it works out of the box instead of needing an on-demand
+# `npx playwright install chrome` (which pulls a pile of apt packages and
+# doesn't persist across container rebuilds). Installed to a world-readable
+# path since it runs as $APACHE_RUN_USER, not root.
+RUN bash --login -i -c 'source /home/devcontainer/.bashrc && npx --yes playwright install --with-deps chrome' \
+    && sudo chmod -R a+rX ${PLAYWRIGHT_BROWSERS_PATH}
 
 WORKDIR /var/www/nextcloud

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,85 @@
+FROM ubuntu:noble
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Base tooling + PHP 8.4 (matches the range supported by this app, see
+# composer.json and appinfo/info.xml)
+RUN apt-get update -y && \
+    apt-get install -y apache2 vim nano sudo gnupg2 wget curl git rsync \
+        software-properties-common lsb-release ca-certificates apt-transport-https && \
+    add-apt-repository ppa:ondrej/php -y && \
+    apt-get update -y
+
+RUN apt-get install --no-install-recommends -y \
+    php8.4 \
+    php8.4-common \
+    php8.4-gd \
+    php8.4-zip \
+    php8.4-curl \
+    php8.4-xml \
+    php8.4-mbstring \
+    php8.4-pgsql \
+    php8.4-intl \
+    php8.4-imagick \
+    php8.4-gmp \
+    php8.4-apcu \
+    php8.4-bcmath \
+    php8.4-opcache \
+    php8.4-cli \
+    php8.4-dev \
+    php8.4-xdebug \
+    libmagickcore-6.q16-7-extra \
+    make \
+    unzip
+
+# Composer
+RUN curl -sS https://getcomposer.org/installer -o /tmp/composer-setup.php && \
+    curl -sS https://composer.github.io/installer.sig -o /tmp/composer-setup.sig && \
+    php -r "if (hash_file('sha384', '/tmp/composer-setup.php') !== trim(file_get_contents('/tmp/composer-setup.sig'))) { echo 'Composer installation failed, invalid hash'; exit(1); }" && \
+    php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer && \
+    rm /tmp/composer-setup.php /tmp/composer-setup.sig
+
+RUN echo "xdebug.remote_enable = 1" >> /etc/php/8.4/cli/conf.d/20-xdebug.ini && \
+    echo "xdebug.remote_autostart = 1" >> /etc/php/8.4/cli/conf.d/20-xdebug.ini && \
+    echo "apc.enable_cli=1" >> /etc/php/8.4/cli/conf.d/20-apcu.ini
+
+# Autostart XDebug for apache
+RUN { \
+    echo "xdebug.mode=debug"; \
+    echo "xdebug.start_with_request=yes"; \
+    } >> /etc/php/8.4/apache2/conf.d/20-xdebug.ini
+
+# Increase PHP memory limit to 512mb
+RUN sed -i 's/memory_limit = .*/memory_limit = 512M/' /etc/php/8.4/apache2/php.ini
+
+# Apache modules required by Nextcloud + vhost pointing at the checkout
+# living in /var/www/nextcloud instead of the default docroot
+RUN a2enmod rewrite headers env dir mime setenvif && \
+    a2dissite 000-default
+COPY apache-nextcloud.conf /etc/apache2/sites-available/nextcloud.conf
+RUN a2ensite nextcloud
+
+# Dedicated DevContainer user runs Apache
+ENV APACHE_RUN_USER=devcontainer
+ENV APACHE_RUN_GROUP=devcontainer
+# Delete any existing user/group with UID/GID 1000 first
+RUN (getent passwd 1000 && userdel -r $(getent passwd 1000 | cut -d: -f1)) || true && \
+    (getent group 1000 && groupdel $(getent group 1000 | cut -d: -f1)) || true && \
+    groupadd -g 1000 ${APACHE_RUN_GROUP} && \
+    useradd -u 1000 -g 1000 -ms /bin/bash ${APACHE_RUN_USER} && \
+    adduser ${APACHE_RUN_USER} sudo && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    sed -ri "s/^export APACHE_RUN_USER=.*$/export APACHE_RUN_USER=${APACHE_RUN_USER}/" "/etc/apache2/envvars" && \
+    sed -ri "s/^export APACHE_RUN_GROUP=.*$/export APACHE_RUN_GROUP=${APACHE_RUN_GROUP}/" "/etc/apache2/envvars"
+
+# Pre-create the (later volume-mounted) Nextcloud directory with the right
+# ownership, so setup.sh can clone/install without needing root.
+RUN mkdir -p /var/www/nextcloud && chown -R ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} /var/www/nextcloud
+
+USER devcontainer
+
+# NVM / NodeJS (matches this app's package.json engines)
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
+RUN bash --login -i -c 'source /home/devcontainer/.bashrc && nvm install 24'
+
+WORKDIR /var/www/nextcloud

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -72,9 +72,12 @@ RUN (getent passwd 1000 && userdel -r $(getent passwd 1000 | cut -d: -f1)) || tr
     sed -ri "s/^export APACHE_RUN_USER=.*$/export APACHE_RUN_USER=${APACHE_RUN_USER}/" "/etc/apache2/envvars" && \
     sed -ri "s/^export APACHE_RUN_GROUP=.*$/export APACHE_RUN_GROUP=${APACHE_RUN_GROUP}/" "/etc/apache2/envvars"
 
-# Pre-create the (later volume-mounted) Nextcloud directory with the right
-# ownership, so setup.sh can clone/install without needing root.
-RUN mkdir -p /var/www/nextcloud && chown -R ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} /var/www/nextcloud
+# Pre-create the (later volume-mounted) Nextcloud directory - including
+# apps/, which is also the parent of the apps/workflow_ocr bind mount - with
+# the right ownership, so setup.sh can clone/install without needing root.
+# Docker copies this tree into the named volume on its first use, which
+# keeps it from auto-creating apps/ as root when the bind mount is set up.
+RUN mkdir -p /var/www/nextcloud/apps && chown -R ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} /var/www/nextcloud
 
 USER devcontainer
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -79,6 +79,8 @@ RUN (getent passwd 1000 && userdel -r $(getent passwd 1000 | cut -d: -f1)) || tr
 # keeps it from auto-creating apps/ as root when the bind mount is set up.
 RUN mkdir -p /var/www/nextcloud/apps && chown -R ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} /var/www/nextcloud
 
+RUN mkdir -p /home/${APACHE_RUN_USER}/.claude && chown -R ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} /home/${APACHE_RUN_USER}/.claude
+
 USER devcontainer
 
 # NVM / NodeJS (matches this app's package.json engines)

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,80 @@
+# workflow_ocr DevContainer
+
+Development container for this app, blueprinted on the
+[official Nextcloud server devcontainer](https://github.com/nextcloud/server/tree/master/.devcontainer).
+
+## Usage
+
+Make sure you have the [VSCode DevContainer](https://code.visualstudio.com/docs/devcontainers/containers)
+extension installed. Open this repository and VSCode will ask you if you want to reopen it inside the
+container (or use <kbd>F1</kbd> &rarr; *Dev Containers: Reopen in Container*).
+
+The default workspace folder is `/var/www/nextcloud/apps/workflow_ocr`, i.e. this repository, bind mounted
+into a Nextcloud installation's `apps` folder.
+
+## What happens on startup
+
+Nextcloud core itself is **not** part of this repository. Instead, on every container start the
+[`setup.sh`](./setup.sh) script (wired up as the devcontainer `postStartCommand`) checks whether
+`/var/www/nextcloud` already contains a cloned and installed Nextcloud instance:
+
+* **If not**, it:
+  1. Reads the `<dependencies><nextcloud max-version="..."/>` entry from this app's
+     [`appinfo/info.xml`](../appinfo/info.xml) to determine the highest Nextcloud version this app declares
+     compatibility with (currently `35`).
+  2. Checks whether the [nextcloud/server](https://github.com/nextcloud/server) repository has a matching
+     `stable<VERSION>` branch (e.g. `stable35`). If it does, that branch is used; otherwise it falls back to
+     `master`.
+  3. Clones that branch as a **shallow, single-branch, single-commit** clone into `/var/www/nextcloud`
+     (merged with the already bind-mounted `apps/workflow_ocr` folder).
+  4. Installs Nextcloud (`occ maintenance:install`) against the `db` Postgres service and enables this app
+     (`occ app:enable workflow_ocr`).
+* **If it's already installed**, this is a fast no-op and Apache is simply (re)started.
+
+Since the checkout is shallow, run [`unshallow.sh`](./unshallow.sh) inside the container whenever you need
+the full git history of the Nextcloud core checkout (e.g. for `git blame`/`bisect` or to switch branches):
+
+```bash
+.devcontainer/unshallow.sh
+```
+
+## Credentials
+
+**Nextcloud Admin Login**
+
+Username: `admin` <br>
+Password: `admin`
+
+**Postgres credentials**
+
+Host: `db` <br>
+Username: `nextcloud` <br>
+Password: `nextcloud` <br>
+Database: `nextcloud`
+
+## Services
+
+Only two services are used, connected via Docker Compose's normal (default) bridge network - no shared
+network namespace tricks:
+
+| Service     | Local port | Description                                    |
+|-------------|------------|-------------------------------------------------|
+| `nextcloud` | `80`       | Apache + PHP serving the cloned Nextcloud instance |
+| `db`        | `5432`     | Postgres database                                |
+
+## Building this app
+
+The devcontainer only takes care of Nextcloud core. To build/install this app's own dependencies, run
+(inside the container, from the workspace folder):
+
+```bash
+make build
+```
+
+Don't forget to enable/refresh the app afterwards via `occ app:enable workflow_ocr` or the Nextcloud web UI.
+
+## Debugging
+
+XDebug is preinstalled and configured to connect to port `9003`. This repository's own
+[`.vscode/launch.json`](../.vscode/launch.json) already ships matching debug profiles (works out of the box
+since the workspace folder is `apps/workflow_ocr`, mirroring a real Nextcloud `apps` installation).

--- a/.devcontainer/apache-nextcloud.conf
+++ b/.devcontainer/apache-nextcloud.conf
@@ -1,0 +1,15 @@
+# Apache vhost pointing at the Nextcloud checkout instead of the default
+# /var/www/html document root.
+<VirtualHost *:80>
+	DocumentRoot /var/www/nextcloud/
+
+	<Directory /var/www/nextcloud/>
+		Require all granted
+		AllowOverride All
+		Options FollowSymLinks MultiViews
+
+		<IfModule mod_dav.c>
+			Dav off
+		</IfModule>
+	</Directory>
+</VirtualHost>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,15 +11,22 @@
 		"vscode": {
 			"extensions": [
 				"felixfbecker.php-debug",
-				"felixfbecker.php-intellisense",
+				"bmewburn.vscode-intelephense-client",
 				"ms-azuretools.vscode-docker",
 				"xdebug.php-debug",
-				"donjayamanne.githistory"
+				"donjayamanne.githistory",
+				"anthropic.claude-code"
 			],
 			"settings": {
 				"php.suggest.basic": false
 			}
 		}
 	},
-	"remoteUser": "devcontainer"
+	"remoteUser": "devcontainer",
+	"mounts": [
+		"source=claude-code-config-wf-ocr,target=/home/devcontainer/.claude,type=volume"
+	],
+	"containerEnv": {
+		"CLAUDE_CONFIG_DIR": "/home/devcontainer/.claude"
+	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+	"name": "WorkflowOcr",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "nextcloud",
+	"workspaceFolder": "/var/www/nextcloud/apps/workflow_ocr",
+	"postStartCommand": ".devcontainer/setup.sh",
+	"forwardPorts": [
+		80
+	],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"felixfbecker.php-debug",
+				"felixfbecker.php-intellisense",
+				"ms-azuretools.vscode-docker",
+				"xdebug.php-debug",
+				"donjayamanne.githistory"
+			],
+			"settings": {
+				"php.suggest.basic": false
+			}
+		}
+	},
+	"remoteUser": "devcontainer"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,49 @@
+# Docker Compose setup for the workflow_ocr devcontainer.
+#
+# Only two services are used:
+#   - "nextcloud": Apache + PHP, running a Nextcloud core checkout which is
+#     cloned on first start (see setup.sh). This app's repository is bind
+#     mounted into its "apps" folder.
+#   - "db": Postgres database used by the Nextcloud installation.
+#
+# No custom "networks:" section and no "network_mode" is used on purpose, so
+# both services are attached to the default bridge network Compose creates
+# for this project and can reach each other by service name (e.g. "db").
+services:
+  nextcloud:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      # Persists the cloned/installed Nextcloud core across container
+      # rebuilds.
+      - nextcloud:/var/www/nextcloud
+      # The app itself (this repository) is what is actually being
+      # developed, so it's bind mounted straight into the apps folder.
+      - ..:/var/www/nextcloud/apps/workflow_ocr:cached
+    command: /var/www/nextcloud/apps/workflow_ocr/.devcontainer/entrypoint.sh
+    ports:
+      - "80:80"
+    depends_on:
+      - db
+    environment:
+      NEXTCLOUD_DB_HOST: db
+      NEXTCLOUD_DB_NAME: nextcloud
+      NEXTCLOUD_DB_USER: nextcloud
+      NEXTCLOUD_DB_PASSWORD: nextcloud
+
+  db:
+    image: postgres:16
+    restart: always
+    environment:
+      POSTGRES_DB: nextcloud
+      POSTGRES_USER: nextcloud
+      POSTGRES_PASSWORD: nextcloud
+    volumes:
+      - db:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+volumes:
+  nextcloud:
+  db:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
   db:
     image: postgres:16
-    restart: always
+    restart: unless-stopped
     environment:
       POSTGRES_DB: nextcloud
       POSTGRES_USER: nextcloud

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Main container process. Starts Apache and keeps the container running.
+#
+# The logic which checks whether Nextcloud is already cloned/installed
+# (and clones + installs it otherwise) lives in setup.sh, which is executed
+# separately via the devcontainer "postStartCommand" once the container is
+# up and the volumes/bind mounts are available.
+sudo service apache2 start
+
+while sleep 1000; do :; done

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -35,8 +35,22 @@ ADMIN_PASSWORD="${NEXTCLOUD_ADMIN_PASSWORD:-admin}"
 git config --global --add safe.directory "$NC_DIR"
 git config --global --add safe.directory "$APP_DIR"
 
+# Docker auto-creates the parent directory of a nested bind mount (here:
+# apps/, the parent of the apps/workflow_ocr bind mount) before the
+# container starts, and does so as root - regardless of who owns the rest
+# of the volume. That silently blocks the (non-root) devcontainer user from
+# creating sibling app directories during the clone below, so reclaim it
+# every start.
+sudo mkdir -p "$NC_DIR/apps"
+sudo chown "${APACHE_RUN_USER:-devcontainer}:${APACHE_RUN_GROUP:-devcontainer}" "$NC_DIR" "$NC_DIR/apps"
+
 is_cloned() {
-    [ -f "$NC_DIR/version.php" ]
+    # apps/files is one of Nextcloud's own core apps and only ends up on
+    # disk if the rsync in clone_nextcloud() fully succeeded, so use it (in
+    # addition to version.php) as a canary for "cloning actually finished".
+    # This also makes an incomplete clone (e.g. from the apps/ permission
+    # issue above, on an older run) self-heal on the next start.
+    [ -f "$NC_DIR/version.php" ] && [ -f "$NC_DIR/apps/files/appinfo/info.xml" ]
 }
 
 is_installed() {

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -44,12 +44,11 @@ git config --global --add safe.directory "$APP_DIR"
 sudo mkdir -p "$NC_DIR/apps"
 sudo chown "${APACHE_RUN_USER:-devcontainer}:${APACHE_RUN_GROUP:-devcontainer}" "$NC_DIR" "$NC_DIR/apps"
 
+if [ -n "$CLAUDE_CONFIG_DIR" ]; then
+    sudo chown -R "$(id -u):$(id -g)" "$CLAUDE_CONFIG_DIR"
+fi
+
 is_cloned() {
-    # apps/files is one of Nextcloud's own core apps and only ends up on
-    # disk if the rsync in clone_nextcloud() fully succeeded, so use it (in
-    # addition to version.php) as a canary for "cloning actually finished".
-    # This also makes an incomplete clone (e.g. from the apps/ permission
-    # issue above, on an older run) self-heal on the next start.
     [ -f "$NC_DIR/version.php" ] && [ -f "$NC_DIR/apps/files/appinfo/info.xml" ]
 }
 
@@ -124,6 +123,11 @@ install_nextcloud() {
         --database-pass="$DB_PASSWORD" \
         --admin-user="$ADMIN_USER" \
         --admin-pass="$ADMIN_PASSWORD"
+
+    echo "==> Installing app dependencies for $APP_NAME"
+    pushd "$APP_DIR" > /dev/null
+    composer install --no-dev
+    popd > /dev/null
 
     echo "==> Enabling $APP_NAME"
     php "$NC_DIR/occ" app:enable "$APP_NAME"

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+#
+# Runs on every container start (devcontainer "postStartCommand").
+#
+# Checks whether Nextcloud is already cloned and installed inside the
+# persistent "nextcloud" volume at /var/www/nextcloud. If not:
+#   1. Determines which Nextcloud server branch is compatible with this app
+#      by reading the <nextcloud max-version="..."/> entry from
+#      appinfo/info.xml, and checking whether a matching "stable<VERSION>"
+#      branch exists in the nextcloud/server repository (falling back to
+#      "master" otherwise).
+#   2. Clones that branch as a shallow, single-branch, single-commit clone
+#      (see unshallow.sh if you ever need the full history).
+#   3. Installs Nextcloud against the "db" Postgres service and enables
+#      this app.
+#
+# Idempotent: if Nextcloud is already installed, this is a (fast) no-op.
+set -eo pipefail
+
+NC_DIR="/var/www/nextcloud"
+APP_NAME="workflow_ocr"
+APP_DIR="$NC_DIR/apps/$APP_NAME"
+NC_REPO_URL="https://github.com/nextcloud/server.git"
+
+DB_HOST="${NEXTCLOUD_DB_HOST:-db}"
+DB_PORT="${NEXTCLOUD_DB_PORT:-5432}"
+DB_NAME="${NEXTCLOUD_DB_NAME:-nextcloud}"
+DB_USER="${NEXTCLOUD_DB_USER:-nextcloud}"
+DB_PASSWORD="${NEXTCLOUD_DB_PASSWORD:-nextcloud}"
+ADMIN_USER="${NEXTCLOUD_ADMIN_USER:-admin}"
+ADMIN_PASSWORD="${NEXTCLOUD_ADMIN_PASSWORD:-admin}"
+
+# Both directories are bind mounts / volumes owned by the container user,
+# but git still insists on an explicit safe.directory entry.
+git config --global --add safe.directory "$NC_DIR"
+git config --global --add safe.directory "$APP_DIR"
+
+is_cloned() {
+    [ -f "$NC_DIR/version.php" ]
+}
+
+is_installed() {
+    is_cloned && php "$NC_DIR/occ" status --output=json 2>/dev/null | grep -Eq '"installed":[[:space:]]*true'
+}
+
+wait_for_db() {
+    echo "==> Waiting for database at ${DB_HOST}:${DB_PORT}"
+    local i=0
+    until (echo >"/dev/tcp/${DB_HOST}/${DB_PORT}") >/dev/null 2>&1; do
+        i=$((i + 1))
+        if [ "$i" -ge 60 ]; then
+            echo "Database did not become available in time" >&2
+            exit 1
+        fi
+        sleep 1
+    done
+}
+
+# Reads the highest Nextcloud version this app declares compatibility with
+# (appinfo/info.xml -> <dependencies><nextcloud max-version="...">) and
+# checks whether a "stable<VERSION>" branch exists for it upstream. Falls
+# back to "master" whenever no version could be determined or no matching
+# branch exists.
+determine_nextcloud_branch() {
+    local max_version
+    max_version=$(sed -n 's/.*<nextcloud[^>]*max-version="\([0-9]*\)".*/\1/p' "$APP_DIR/appinfo/info.xml" | head -n1)
+
+    if [ -z "$max_version" ]; then
+        echo "master"
+        return
+    fi
+
+    local candidate="stable${max_version}"
+    # Query the fully-qualified ref: an unqualified "stableXX" pattern also
+    # matches "backport/NNNNN/stableXX" branches via git's suffix matching.
+    if [ -n "$(git ls-remote --heads "$NC_REPO_URL" "refs/heads/${candidate}")" ]; then
+        echo "$candidate"
+    else
+        echo "master"
+    fi
+}
+
+clone_nextcloud() {
+    local branch
+    branch="$(determine_nextcloud_branch)"
+    echo "==> Cloning nextcloud/server (branch: ${branch}, shallow single-branch/single-commit)"
+
+    local staging_dir
+    staging_dir="$(mktemp -d)"
+
+    git clone --branch "$branch" --single-branch --depth 1 "$NC_REPO_URL" "$staging_dir"
+    git -C "$staging_dir" submodule update --init --recursive --depth 1
+
+    # $NC_DIR already contains the bind-mounted apps/workflow_ocr directory
+    # (this app), so merge the freshly cloned core sources into it instead
+    # of cloning straight into it.
+    rsync -a "$staging_dir"/ "$NC_DIR"/
+    rm -rf "$staging_dir"
+}
+
+install_nextcloud() {
+    echo "==> Installing Nextcloud"
+    php "$NC_DIR/occ" maintenance:install \
+        --verbose \
+        --database=pgsql \
+        --database-name="$DB_NAME" \
+        --database-host="$DB_HOST" \
+        --database-port="$DB_PORT" \
+        --database-user="$DB_USER" \
+        --database-pass="$DB_PASSWORD" \
+        --admin-user="$ADMIN_USER" \
+        --admin-pass="$ADMIN_PASSWORD"
+
+    echo "==> Enabling $APP_NAME"
+    php "$NC_DIR/occ" app:enable "$APP_NAME"
+}
+
+wait_for_db
+
+if is_installed; then
+    echo "Nextcloud is already cloned and installed, nothing to do."
+else
+    is_cloned || clone_nextcloud
+    install_nextcloud
+fi
+
+sudo service apache2 restart

--- a/.devcontainer/unshallow.sh
+++ b/.devcontainer/unshallow.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# The Nextcloud core checkout at /var/www/nextcloud is created by setup.sh
+# as a shallow, single-branch, single-commit clone to keep the initial
+# container setup fast (see setup.sh -> clone_nextcloud).
+#
+# Run this script manually whenever you need the full git history for that
+# checkout, for example to `git blame`, `git bisect`, or switch to a
+# different branch/tag/commit.
+set -eo pipefail
+
+NC_DIR="/var/www/nextcloud"
+
+if [ ! -d "$NC_DIR/.git" ]; then
+    echo "No git checkout found at $NC_DIR" >&2
+    exit 1
+fi
+
+echo "==> Unshallowing Nextcloud checkout at $NC_DIR (this may take a while)"
+git -C "$NC_DIR" fetch --unshallow
+git -C "$NC_DIR" remote set-branches origin '*'
+git -C "$NC_DIR" fetch --all --tags
+
+echo "Done. $NC_DIR is now a full clone."

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ js
 coverage
 .php-cs-fixer.cache 
 .vscode/settings.json
+.playwright-mcp

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@playwright/mcp@latest", "--headless"],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a complete DevContainer setup for local development of the workflow_ocr app, enabling developers to work within a containerized Nextcloud environment using VSCode's DevContainer extension.

## Key Changes
- **Dockerfile**: Ubuntu-based image with PHP 8.4, Apache, Composer, Node.js (via NVM), and XDebug pre-configured for debugging
- **docker-compose.yml**: Two-service setup (Apache/PHP and PostgreSQL) with persistent volumes and proper networking
- **setup.sh**: Intelligent initialization script that:
  - Determines compatible Nextcloud version from `appinfo/info.xml`
  - Clones the appropriate Nextcloud server branch (shallow clone for speed)
  - Installs Nextcloud and enables the app on first container start
  - Idempotent design—subsequent starts are fast no-ops
- **devcontainer.json**: VSCode configuration with recommended extensions (PHP debugging, Docker, Git history) and workspace setup
- **entrypoint.sh**: Container startup script that begins Apache and keeps the container running
- **unshallow.sh**: Utility script to convert the shallow Nextcloud clone to a full repository when needed for advanced git operations
- **apache-nextcloud.conf**: Apache vhost configuration pointing to the Nextcloud checkout
- **README.md**: Comprehensive documentation covering usage, startup behavior, credentials, services, building, and debugging

## Notable Implementation Details
- The app repository is bind-mounted into the Nextcloud `apps` folder, allowing live development
- Nextcloud core is cloned on first start based on the app's declared max version compatibility, with automatic fallback to `master` if no matching stable branch exists
- XDebug is pre-configured and integrated with VSCode launch profiles for seamless debugging
- The setup script uses `rsync` to merge the cloned Nextcloud core with the already bind-mounted app directory, avoiding conflicts
- Database connectivity is verified before installation with a 60-second timeout
- All services use the default Docker Compose bridge network for straightforward service-to-service communication

https://claude.ai/code/session_018aAofv31CzWr6EW3zbPocH