### PR TITLE
Fix OS command injection via workflow OCR language settings (CWE-78)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,6 @@
 			"OCA\\WorkflowOcr\\": "lib/"
 		}
 	},
-	"autoload-dev": {
-		"psr-4": {
-			"OCP\\": "vendor/nextcloud/ocp/OCP"
-		}
-	},
     "scripts": {
         "lint": "find . -name \\*.php -not -path './vendor/*' -not -path './node_modules/*' -exec php -l \"{}\" \\;",
         "cs:check": "php-cs-fixer fix --dry-run --diff",

--- a/composer.lock
+++ b/composer.lock
@@ -2060,16 +2060,16 @@
         },
         {
             "name": "php-cs-fixer/shim",
-            "version": "v3.95.19",
+            "version": "v3.95.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/shim.git",
-                "reference": "bd697e5e3bb17b83d4690a7238f2c7b5a131bb12"
+                "reference": "85ccbf0b084d0dae3dbeb2dca8e5bd4ced13c265"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/bd697e5e3bb17b83d4690a7238f2c7b5a131bb12",
-                "reference": "bd697e5e3bb17b83d4690a7238f2c7b5a131bb12",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/85ccbf0b084d0dae3dbeb2dca8e5bd4ced13c265",
+                "reference": "85ccbf0b084d0dae3dbeb2dca8e5bd4ced13c265",
                 "shasum": ""
             },
             "require": {
@@ -2106,9 +2106,9 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/shim/issues",
-                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.95.19"
+                "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.95.20"
             },
-            "time": "2026-08-17T16:24:34+00:00"
+            "time": "2026-08-19T16:28:36+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/lib/Model/WorkflowSettings.php
+++ b/lib/Model/WorkflowSettings.php
@@ -34,6 +34,13 @@ class WorkflowSettings {
 	public const OCR_MODE_FORCE_OCR = 2;
 	public const OCR_MODE_SKIP_FILE = 3;
 
+	/**
+	 * Allow-list for tesseract/ocrmypdf language codes (e.g. 'eng', 'chi_sim', 'script/Latin').
+	 * Used to reject anything that could be (ab)used as a shell metacharacter once the
+	 * languages are concatenated into the ocrmypdf command line.
+	 */
+	private const LANGUAGE_CODE_REGEX = '/^[A-Za-z][A-Za-z0-9_\/]{0,31}$/';
+
 	/** @var array */
 	private $languages = [];
 
@@ -187,7 +194,7 @@ class WorkflowSettings {
 		if ($data === null) {
 			throw new InvalidArgumentException('Invalid JSON: "' . $json . '"');
 		}
-		$this->setProperty($this->languages, $data, 'languages', fn ($value) => is_array($value));
+		$this->setProperty($this->languages, $data, 'languages', fn ($value) => self::isValidLanguagesArray($value));
 		$this->setProperty($this->removeBackground, $data, 'removeBackground', fn ($value) => is_bool($value));
 		$this->setProperty($this->ocrMode, $data, 'ocrMode', fn ($value) => is_int($value));
 		$this->setProperty($this->tagsToRemoveAfterOcr, $data, 'tagsToRemoveAfterOcr', fn ($value) => is_array($value));
@@ -205,5 +212,26 @@ class WorkflowSettings {
 		if (array_key_exists($key, $jsonData) && ($dataCheck === null || $dataCheck($jsonData[$key]))) {
 			$property = $jsonData[$key];
 		}
+	}
+
+	/**
+	 * Validates that $value is an array of strings, each matching the allow-listed
+	 * language code pattern. This is a security relevant check: the language values
+	 * end up being concatenated into a shell command (see CommandLineUtils), so any
+	 * value not matching the allow-list must be rejected here.
+	 *
+	 * @param mixed $value
+	 * @return bool
+	 */
+	private static function isValidLanguagesArray($value): bool {
+		if (!is_array($value)) {
+			return false;
+		}
+		foreach ($value as $language) {
+			if (!is_string($language) || preg_match(self::LANGUAGE_CODE_REGEX, $language) !== 1) {
+				return false;
+			}
+		}
+		return true;
 	}
 }

--- a/lib/OcrProcessors/CommandLineUtils.php
+++ b/lib/OcrProcessors/CommandLineUtils.php
@@ -29,6 +29,15 @@ use OCA\WorkflowOcr\Service\IOcrBackendInfoService;
 use Psr\Log\LoggerInterface;
 
 class CommandLineUtils implements ICommandLineUtils {
+	/**
+	 * Allow-list for tesseract/ocrmypdf language codes (e.g. 'eng', 'chi_sim', 'script/Latin').
+	 * The language values are concatenated into the ocrmypdf command line, which is executed
+	 * as a shell string, so anything not matching this pattern must never reach it. This is
+	 * enforced again here (in addition to WorkflowSettings validation) as defense in depth,
+	 * e.g. for workflows that were stored before this validation was introduced.
+	 */
+	private const LANGUAGE_CODE_REGEX = '/^[A-Za-z][A-Za-z0-9_\/]{0,31}$/';
+
 	private static $ocrModeToCmdParameterMapping = [
 		WorkflowSettings::OCR_MODE_SKIP_TEXT => '--skip-text',
 		WorkflowSettings::OCR_MODE_REDO_OCR => '--redo-ocr',
@@ -52,8 +61,9 @@ class CommandLineUtils implements ICommandLineUtils {
 		$args[] = self::$ocrModeToCmdParameterMapping[$settings->getOcrMode()];
 
 		// Language settings
-		if ($settings->getLanguages()) {
-			$langStr = implode('+', $settings->getLanguages());
+		$languages = $this->filterValidLanguages($settings->getLanguages());
+		if ($languages) {
+			$langStr = implode('+', $languages);
 			$args[] = "--language $langStr";
 		}
 
@@ -91,5 +101,23 @@ class CommandLineUtils implements ICommandLineUtils {
 		$customCliArgs = str_replace('&&', '', $customCliArgs);
 		$customCliArgs = str_replace(';', '', $customCliArgs);
 		return $customCliArgs;
+	}
+
+	/**
+	 * Filters out any language value that does not match the allow-listed language
+	 * code pattern. This value is concatenated into a shell command, so entries that
+	 * don't look like a valid tesseract language code must never be passed through.
+	 *
+	 * @param array $languages
+	 * @return array
+	 */
+	private function filterValidLanguages(array $languages): array {
+		return array_values(array_filter($languages, function ($language) {
+			if (!is_string($language) || preg_match(self::LANGUAGE_CODE_REGEX, $language) !== 1) {
+				$this->logger->warning('Ignoring invalid OCR language value: ' . var_export($language, true));
+				return false;
+			}
+			return true;
+		}));
 	}
 }

--- a/tests/Unit/Model/WorkflowSettingsTest.php
+++ b/tests/Unit/Model/WorkflowSettingsTest.php
@@ -93,7 +93,33 @@ class WorkflowSettingsTest extends TestCase {
 				'{"removeBackground":true,"languages":["eng","deu","spa","fra","ita"],"keepOriginalFileVersion":false}',
 				true,
 				['eng', 'deu', 'spa', 'fra', 'ita']
+			],
+			[
+				'{"languages":["chi_sim","script/Latin"]}',
+				false,
+				['chi_sim', 'script/Latin']
 			]
+		];
+	}
+
+	#[DataProvider('dataProvider_testMaliciousLanguagesAreRejected')]
+	public function testLanguagesContainingShellMetacharactersAreRejected(string $json) {
+		// The whole 'languages' value must be rejected (falls back to the default empty
+		// array) as soon as a single entry doesn't look like a valid language code, since
+		// these values end up being concatenated into a shell command.
+		$workflowSettings = new WorkflowSettings($json);
+		$this->assertEquals([], $workflowSettings->getLanguages());
+	}
+
+	public static function dataProvider_testMaliciousLanguagesAreRejected() {
+		return [
+			['{"languages":["eng","x ; id > /tmp/pwned ; echo z"]}'],
+			['{"languages":["eng","x && id"]}'],
+			['{"languages":["eng","x | id"]}'],
+			['{"languages":["eng","$(id)"]}'],
+			['{"languages":["eng","`id`"]}'],
+			['{"languages":["eng "]}'],
+			['{"languages":[123]}'],
 		];
 	}
 }

--- a/tests/Unit/OcrProcessors/CommandLineUtilsTest.php
+++ b/tests/Unit/OcrProcessors/CommandLineUtilsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2026 Robin Windey <ro.windey@gmail.com>
+ *
+ *  @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\WorkflowOcr\Tests\Unit\OcrProcessors;
+
+use OCA\WorkflowOcr\Model\GlobalSettings;
+use OCA\WorkflowOcr\Model\WorkflowSettings;
+use OCA\WorkflowOcr\OcrProcessors\CommandLineUtils;
+use OCA\WorkflowOcr\Service\IOcrBackendInfoService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class CommandLineUtilsTest extends TestCase {
+	/** @var IOcrBackendInfoService|MockObject */
+	private $ocrBackendInfoService;
+	/** @var LoggerInterface|MockObject */
+	private $logger;
+	private CommandLineUtils $commandLineUtils;
+
+	protected function setUp(): void {
+		$this->ocrBackendInfoService = $this->createMock(IOcrBackendInfoService::class);
+		$this->ocrBackendInfoService->method('isRemoteBackend')->willReturn(false);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->commandLineUtils = new CommandLineUtils($this->ocrBackendInfoService, $this->logger);
+	}
+
+	public function testValidLanguagesAreIncludedInCommandline(): void {
+		$settings = new WorkflowSettings('{"languages":["eng","deu"]}');
+		$globalSettings = new GlobalSettings();
+
+		$result = $this->commandLineUtils->getCommandlineArgs($settings, $globalSettings);
+
+		$this->assertStringContainsString('--language eng+deu', $result);
+	}
+
+	/**
+	 * Defense-in-depth regression test for the OS command injection reported via
+	 * `languages`: even if a WorkflowSettings instance somehow carries a malicious
+	 * language value (e.g. a workflow stored before input validation was added),
+	 * CommandLineUtils must never let it reach the shell command string.
+	 */
+	public function testMaliciousLanguageValueIsFilteredOutOfCommandline(): void {
+		$settings = $this->createMock(WorkflowSettings::class);
+		$settings->method('getLanguages')->willReturn(['eng', 'x ; id > /tmp/pwned ; echo z']);
+		$settings->method('getOcrMode')->willReturn(WorkflowSettings::OCR_MODE_SKIP_TEXT);
+		$settings->method('getRemoveBackground')->willReturn(false);
+		$settings->method('getCustomCliArgs')->willReturn('');
+		$globalSettings = new GlobalSettings();
+
+		$result = $this->commandLineUtils->getCommandlineArgs($settings, $globalSettings);
+
+		$this->assertStringContainsString('--language eng', $result);
+		$this->assertStringNotContainsString(';', $result);
+		$this->assertStringNotContainsString('id >', $result);
+	}
+}


### PR DESCRIPTION
WorkflowSettings.languages was validated with is_array() only. Its elements were concatenated unescaped into the ocrmypdf command line (CommandLineUtils::getCommandlineArgs), which is executed as a raw shell string via mikehaertl/php-shellcommand's proc_open(). Unlike customCliArgs, languages was never passed through the ';'/'&&' stripping applied by escapeCustomCliArgs(), so any authenticated user able to create a personal workflow (workflowengine API, #[NoAdminRequired]) could inject arbitrary shell commands that ran as the web server user once a matching file was processed.

Fix, in two layers:
- WorkflowSettings now validates every language value against an allow-list pattern for tesseract/ocrmypdf language codes (letters/digits/underscore/slash, e.g. 'eng', 'chi_sim', 'script/Latin'); an invalid array is rejected like any other malformed field, so a workflow with a malicious language value cannot be saved.
- CommandLineUtils applies the same allow-list again immediately before building the command line, filtering out and logging any value that doesn't match, as defense in depth for workflows stored before this fix.

Adds regression tests covering shell-metacharacter payloads (';', '&&', '|', '$()', backticks) for both layers.

Reported by Duc Anh Nguyen (@gladiator9797).