### PR TITLE
fix(ocr): make file extension check case-insensitive

### DIFF
--- a/lib/Service/OcrService.php
+++ b/lib/Service/OcrService.php
@@ -392,7 +392,7 @@ class OcrService implements IOcrService {
 	 */
 	private function determineNewFilePath(Node $file, string $originalFileExtension): string {
 		$filePath = $file->getPath();
-		if ($originalFileExtension !== self::PDF_FILE_EXTENSION) {
+		if (strtolower($originalFileExtension) !== self::PDF_FILE_EXTENSION) {
 			// If the extension changed, will create a new file with the new extension
 			return "$filePath." . self::PDF_FILE_EXTENSION;
 		}

--- a/tests/Unit/Service/OcrServiceTest.php
+++ b/tests/Unit/Service/OcrServiceTest.php
@@ -922,6 +922,7 @@ class OcrServiceTest extends TestCase {
 	public static function dataProvider_OriginalAndNewFilesnames() {
 		return [
 			['somefile.pdf', 'somefile.pdf'],
+			['somefile.PDF', 'somefile.PDF'],
 			['somefile.jpg', 'somefile.jpg.pdf']
 		];
 	}


### PR DESCRIPTION
#### **Problem**

When processing files with uppercase extensions (e.g., `.PDF`), the strict comparison `$originalFileExtension !== self::PDF_FILE_EXTENSION` evaluates to `true`. As a result, the application treats the PDF file as a non-PDF file and appends `.pdf` to the filename, creating unwanted duplicate files like `filename.PDF.pdf`.

#### **Solution**

Used `strtolower()` on `$originalFileExtension` in `determineNewFilePath()` (`lib/Service/OcrService.php`) to make the extension check case-insensitive.

#### **Testing**

Tested on a production Nextcloud instance processing files with `.PDF` extensions. The OCR process now overwrites the original file directly without creating `.PDF.pdf` duplicates.
