### PR TITLE
Replace Folder with IUserFolder in NotifierTest mocks

### DIFF
--- a/tests/Unit/Notification/NotifierTest.php
+++ b/tests/Unit/Notification/NotifierTest.php
@@ -29,8 +29,8 @@ namespace OCA\WorkflowOcr\Tests\Unit\Notification;
 use OC\Notification\Notification;
 use OCA\WorkflowOcr\Notification\Notifier;
 use OCP\Files\File;
-use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\IUserFolder;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
@@ -153,8 +153,8 @@ class NotifierTest extends TestCase {
 		$file->expects($this->once())
 			->method('getId')
 			->willReturn('123');
-		/** @var Folder|MockObject */
-		$userFolder = $this->createMock(Folder::class);
+		/** @var IUserFolder|MockObject */
+		$userFolder = $this->createMock(IUserFolder::class);
 		$userFolder->expects($this->once())
 			->method('getById')
 			->with('123')
@@ -252,8 +252,8 @@ class NotifierTest extends TestCase {
 		$notification->setSubject('ocr_error', ['message' => 'mymessage']);
 		$notification->setObject('file', '123');
 
-		/** @var Folder|MockObject */
-		$userFolder = $this->createMock(Folder::class);
+		/** @var IUserFolder|MockObject */
+		$userFolder = $this->createMock(IUserFolder::class);
 		$ex = new \OCP\Files\NotFoundException('nope ... sorry');
 		$userFolder->expects($this->once())
 			->method('getById')
@@ -302,8 +302,8 @@ class NotifierTest extends TestCase {
 		$notification->setSubject('ocr_error', ['message' => 'mymessage']);
 		$notification->setObject('file', '123');
 
-		/** @var Folder|MockObject */
-		$userFolder = $this->createMock(Folder::class);
+		/** @var IUserFolder|MockObject */
+		$userFolder = $this->createMock(IUserFolder::class);
 		$userFolder->expects($this->once())
 			->method('getById')
 			->with('123')


### PR DESCRIPTION
## Summary
Updates the `NotifierTest` unit test to use the `IUserFolder` interface instead of the concrete `Folder` class when creating mock objects. This aligns with Nextcloud API best practices of depending on interfaces rather than concrete implementations.

## Changes
- Updated import statements: removed `OCP\Files\Folder`, added `OCP\Files\IUserFolder`
- Replaced three mock object creations from `Folder::class` to `IUserFolder::class` in test methods:
  - `testPrepareConstructsOcrErrorCorrectlyWithFileId()`
  - `testSendsFallbackNotificationWithoutFileInfoIfFileNotFoundWasThrownByGetById()`
  - `testSendsFallbackNotificationWithoutFileInfoIfReturnedFileArrayWasEmpty()`
- Updated corresponding PHPDoc type hints from `Folder|MockObject` to `IUserFolder|MockObject`

## Implementation Details
This change improves test maintainability by mocking against the interface contract (`IUserFolder`) rather than a concrete implementation (`Folder`). The test behavior remains unchanged since `IUserFolder` defines the same `getById()` method that was being mocked. This follows the convention established in `lib/Wrapper/` where services depend on interfaces for testability.

https://claude.ai/code/session_015NSKb4ffhDhYYbqNtnNFsT